### PR TITLE
fixed posting errors

### DIFF
--- a/src/components/APIErrorAlert.tsx
+++ b/src/components/APIErrorAlert.tsx
@@ -39,7 +39,7 @@ const APIErrorAlert: React.FC<Props> = (props) => {
   }, [error]);
 
   return (
-    <Stack sx={(theme) => ({ margin: theme.spacing(2) })} spacing={2}>
+    <Stack sx={(theme) => ({ margin: theme.spacing(3) })} spacing={2}>
       <Alert severity="error">
         {myMessage}
         {errorString ? ` (${errorString})` : ""}

--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -15,7 +15,10 @@ const DownloadPage: React.FC<void> = () => {
   const [urls, setUrls] = useState<string[]>([]);
 
   useEffect(() => {
-    getPresignedUrls({ keys });
+    if (!keys) return;
+    // Ensure keys is always an array, even if there's only one key
+    const keysArray = Array.isArray(keys) ? keys : [keys];
+    getPresignedUrls({ keys: keysArray });
   }, [getPresignedUrls, keys]);
   
   if (isGetLoading) {

--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Stack, Typography, LinearProgress } from "@mui/material";
 import Head from "next/head";
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState } from "react";
 import { useGetPresignedUrlsMutation } from "@/services/base";
 import { useRouter } from "next/router";
 import { APIErrorAlert } from "@/components/APIErrorAlert";

--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -16,7 +16,7 @@ const DownloadPage: React.FC<void> = () => {
 
   useEffect(() => {
     getPresignedUrls({ keys });
-  }, []);
+  }, [getPresignedUrls, keys]);
   
   if (isGetLoading) {
     return <LinearProgress />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,8 +19,8 @@ const Home: React.FC<void> = () => {
         sx={{ minHeight: "100vh" }}
         spacing={5}
       >
-        <Image src="/images/filelink_usecase.png" alt="Image of how filelink works " width={500} height={300} />
-        {/* <Typography variant="h3">FileLink</Typography> */}
+        {/* <Image src="/images/filelink_usecase.png" alt="Image of how filelink works " width={500} height={300} /> */}
+        <Typography variant="h3">FileLink</Typography>
         <Link href={`/share`}>
           <Button size="large" variant="contained" sx={{ backgroundColor: "#406671", ":hover": { backgroundColor: "#264d5b" } }}>Start</Button>
         </Link>

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -19,7 +19,7 @@ export const baseApi = api.injectEndpoints({
       query: ({ keys }) => ({
         url: `getPresignedUrls`,
         method: "POST",
-        body: { keys },
+        body: { keys: keys },
       }),
       transformResponse: (resp: GetPresignedRes) => resp,
     }),
@@ -29,7 +29,7 @@ export const baseApi = api.injectEndpoints({
       query: ({ numOfFiles }) => ({
         url: `postPresignedUrls`,
         method: "POST",
-        body: { numOfFiles },
+        body: { numOfFiles: numOfFiles },
       }),
       transformResponse: (resp: PostPresignedRes) => resp,
     }),

--- a/src/services/base.ts
+++ b/src/services/base.ts
@@ -19,7 +19,7 @@ export const baseApi = api.injectEndpoints({
       query: ({ keys }) => ({
         url: `getPresignedUrls`,
         method: "POST",
-        body: { keys: keys },
+        body: { keys },
       }),
       transformResponse: (resp: GetPresignedRes) => resp,
     }),
@@ -29,7 +29,7 @@ export const baseApi = api.injectEndpoints({
       query: ({ numOfFiles }) => ({
         url: `postPresignedUrls`,
         method: "POST",
-        body: { numOfFiles: numOfFiles },
+        body: { numOfFiles },
       }),
       transformResponse: (resp: PostPresignedRes) => resp,
     }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
### Problem
When uploading one object, it causes an error when downloading.

### Cause
- When sending an http request, even though it seems the code sends the 'keys' as string array since it is set as string[] in TypeScript, the 'keys' is actually converted into a string if there is only one key when it is converted from TypeScript to JavaScript.

### Fix
- Separate the cases when there is only one key and there are multiple keys. If there is only one key, convert it to string[] explicitly since it is converted into string in JavaScript if I don't specify the type.